### PR TITLE
[verilog] Drop references to TODO and DEPRECATED comment formatting

### DIFF
--- a/VerilogCodingStyle.md
+++ b/VerilogCodingStyle.md
@@ -162,10 +162,7 @@ In particular, we inherit these specific formatting guidelines:
 *   Maintain consistent and good
     [punctuation, spelling, and grammar](https://google.github.io/styleguide/cppguide.html#Punctuation,_Spelling_and_Grammar)
     (within comments).
-*   Use standard formatting for [comments](#comments),
-    including C-like formatting for [TODO](https://google.github.io/styleguide/cppguide.html#TODO_Comments)
-    and
-    [deprecation](https://google.github.io/styleguide/cppguide.html#Deprecation_Comments).
+*   Use standard formatting for [comments](#comments).
 
 ### Style Guide Exceptions
 


### PR DESCRIPTION
As pointed out in #6, the section on DEPRECATED comments hsa been
removed from the Google C++ style guide. We currently specifically link
to guidance in that style guide on formatting for TODO and DEPRECATED
comments, but in practice we don't encourage that style - especially not
the TODO(owner) style suggested in the C++ doc.

Fixes #6.