### PR TITLE
blocking assignment must be used for a clock divider

### DIFF
--- a/VerilogCodingStyle.md
+++ b/VerilogCodingStyle.md
@@ -1756,6 +1756,18 @@ an always block as occurring in a separate simulation event as the non-blocking
 assignment. This process makes some signals jump registers, potentially leading
 to total protonic reversal. That's bad.
 
+Exception: For a clock divider blocking assingment must be used not to case race condition.
+
+&#x1f44d;
+```systemverilog {.good}
+logic clk_div2;
+always_ff @(posedge clk or negedge rst_ni) begin
+  // only for a clock divider blocking assignment must be used not to cause race condition
+  if (!rst_ni) clk_div2 = 1'b0;
+  else         clk_div2 = ~clk_div2;
+end
+```
+
 Sequential statements for state assignments should only contain reset values and
 a next-state to state assignment, use a separate combinational-only block to
 generate that next-state value.

--- a/VerilogCodingStyle.md
+++ b/VerilogCodingStyle.md
@@ -1732,6 +1732,18 @@ an always block as occurring in a separate simulation event as the non-blocking
 assignment. This process makes some signals jump registers, potentially leading
 to total protonic reversal. That's bad.
 
+Exception: For a clock divider blocking assingment must be used not to case race condition.
+
+&#x1f44d;
+```systemverilog {.good}
+logic clk_div2;
+always_ff @(posedge clk or negedge rst_ni) begin
+  // only for a clock divider blocking assignment must be used not to cause race condition
+  if (!rst_ni) clk_div2 = 1'b0;
+  else         clk_div2 = ~clk_div2;
+end
+```
+
 Sequential statements for state assignments should only contain reset values and
 a next-state to state assignment, use a separate combinational-only block to
 generate that next-state value.

--- a/VerilogCodingStyle.md
+++ b/VerilogCodingStyle.md
@@ -1590,7 +1590,7 @@ Exceptions:
 
 *   When using parameterized widths, it is acceptable to simply use `1'b1` (e.g.
     when incrementing) rather than contrivances such as
-    `Bus_width'(1)`.
+    `{{(Bus_width-1){1'b0}}, 1'b1}`. Alternately it could be written as `Bus_width'(1)`.
 *   It is acceptable to use the '0 construct to create an automatic correctly
     sized zero.
 *   Literals assigned to integer variants (e.g. byte, shortint, int, integer,
@@ -1698,14 +1698,14 @@ is to silently drop the carry on assignment.
 Example:
 
 ```systemverilog
-logic [3:0] cnt, ncnt;
-assign ncnt = cnt + 4'h1;
+logic [3:0] cnt_d, cnt_q;
+assign cnt_d = cnt_q + 4'h1;
 ```
 
 Or you may explicitly express dropping the carry by using size casting.
 
 ```systemverilog
-assign ncnt = 4'(cnt + 4'h1);
+assign cnt_d = 4'(cnt_q + 4'h1);
 ```
 
 ### Blocking and Non-blocking Assignments

--- a/VerilogCodingStyle.md
+++ b/VerilogCodingStyle.md
@@ -1756,18 +1756,6 @@ an always block as occurring in a separate simulation event as the non-blocking
 assignment. This process makes some signals jump registers, potentially leading
 to total protonic reversal. That's bad.
 
-Exception: For a clock divider blocking assignment must be used not to cause race condition.
-
-&#x1f44d;
-```systemverilog {.good}
-logic clk_div2;
-always_ff @(posedge clk or negedge rst_ni) begin
-  // only for a clock divider blocking assignment must be used not to cause race condition
-  if (!rst_ni) clk_div2 = 1'b0;
-  else         clk_div2 = ~clk_div2;
-end
-```
-
 Sequential statements for state assignments should only contain reset values and
 a next-state to state assignment, use a separate combinational-only block to
 generate that next-state value.

--- a/VerilogCodingStyle.md
+++ b/VerilogCodingStyle.md
@@ -2545,8 +2545,11 @@ initialization. For example:
 &#x1f44d;
 ```systemverilog {.good}
 wire [7:0] sum = a + b;  // Continuous assignment
+```
 
-logic [7:0] acc = '0;  // Initialization
+&#x1f44e;
+```systemverilog {.bad}
+logic [7:0] acc = '0;  // Initialization (not synthesizable)
 ```
 
 There are exceptions for places where `logic` is inappropriate. For example,

--- a/VerilogCodingStyle.md
+++ b/VerilogCodingStyle.md
@@ -2201,7 +2201,7 @@ such that an `X` in the case expression may match one or more case items.
 performs exact matches for undriven `X` inputs. While this does not completely
 fix the problems with symmetric wildcard matching, it is harder to accidentally
 produce a `Z` input than an `X` input, so this form is preferred.
-`case inside` does not treat either `X` nor `Z` in the case expression as a
+`case inside` does not treat either `X` or `Z` in the case expression as a
 wildcard, so this form is more preferred than `casez`.
 
 References:

--- a/VerilogCodingStyle.md
+++ b/VerilogCodingStyle.md
@@ -1756,7 +1756,7 @@ an always block as occurring in a separate simulation event as the non-blocking
 assignment. This process makes some signals jump registers, potentially leading
 to total protonic reversal. That's bad.
 
-Exception: For a clock divider blocking assignment must be used not to case race condition.
+Exception: For a clock divider blocking assignment must be used not to cause race condition.
 
 &#x1f44d;
 ```systemverilog {.good}
@@ -2201,7 +2201,7 @@ such that an `X` in the case expression may match one or more case items.
 performs exact matches for undriven `X` inputs. While this does not completely
 fix the problems with symmetric wildcard matching, it is harder to accidentally
 produce a `Z` input than an `X` input, so this form is preferred.
-`case inside` does not treat either `X` nor `Z` in the case extression as a
+`case inside` does not treat either `X` nor `Z` in the case expression as a
 wildcard, so this form is more preferred than `casez`.
 
 References:

--- a/VerilogCodingStyle.md
+++ b/VerilogCodingStyle.md
@@ -2248,12 +2248,13 @@ Example of implicit signed-to-unsigned casting:
 ```systemverilog
 logic signed [7:0]  a;
 logic               incr;
-logic signed [15:0] sum1, sum2;
+logic signed [15:0] sum1, sum2, sum3;
 initial begin
-  a = 8'sh80;
+  a = 8'sh80;                        // a = -128
   incr = 1'b1;
-  sum1 = a + incr;                   // sum1 = 16'h0081
-  sum2 = a + signed'({1'b0, incr});  // sum2 = 16'hFF81
+  sum1 = a + incr;                   // sum1 = 16'h0081 ( 129)
+  sum2 = a + signed'({1'b0, incr});  // sum2 = 16'hFF81 (-127)
+  sum3 = a + 8'sh01;                 // sum3 = sum2 (but simpler)
 end
 ```
 

--- a/VerilogCodingStyle.md
+++ b/VerilogCodingStyle.md
@@ -2146,10 +2146,11 @@ always_comb begin
 end
 ```
 
-##### Wildcards in case items
+#### Wildcards in case items
 
-Use `case` instead of `casez` whenever wildcard operator behavior is not
-required. When wildcard behavior is needed, use `casez`.
+Use `case` instead of `case inside` nor `casez` whenever wildcard operator
+behavior is not required. When wildcard behavior is needed, use `case inside`
+(or `casez` if only Verilog-2001 is supported).
 
 When expressing a wildcard in a case item, use the '?' character since it more
 clearly expresses the intent.
@@ -2160,7 +2161,8 @@ such that an `X` in the case expression may match one or more case items.
 performs exact matches for undriven `X` inputs. While this does not completely
 fix the problems with symmetric wildcard matching, it is harder to accidentally
 produce a `Z` input than an `X` input, so this form is preferred.
-
+`case inside` does not treat either `X` nor `Z` in the case extression as a
+wildcard, so this form is more preferred than `casez`.
 
 References:
 

--- a/VerilogCodingStyle.md
+++ b/VerilogCodingStyle.md
@@ -2573,7 +2573,14 @@ wire [7:0] sum = a + b;  // Continuous assignment
 
 &#x1f44e;
 ```systemverilog {.bad}
-logic [7:0] acc = '0;  // Initialization (not synthesizable)
+logic [7:0] sum = a + b; // Initialization (not synthesizable)
+```
+
+`sum` is initialized to sum of initial values of a and b.
+
+&#x1f44d;
+```systemverilog {.good}
+logic [7:0] acc = '0;    // Initialization (synthesizable on some FPGA tools)
 ```
 
 There are exceptions for places where `logic` is inappropriate. For example,

--- a/VerilogCodingStyle.md
+++ b/VerilogCodingStyle.md
@@ -1702,7 +1702,7 @@ logic [3:0] cnt, ncnt;
 assign ncnt = cnt + 4'h1;
 ```
 
-Or you may explicitly express to drop the carry by using size casting.
+Or you may explicitly express dropping the carry by using size casting.
 
 ```systemverilog
 assign ncnt = 4'(cnt + 4'h1);
@@ -1756,7 +1756,7 @@ an always block as occurring in a separate simulation event as the non-blocking
 assignment. This process makes some signals jump registers, potentially leading
 to total protonic reversal. That's bad.
 
-Exception: For a clock divider blocking assingment must be used not to case race condition.
+Exception: For a clock divider blocking assignment must be used not to case race condition.
 
 &#x1f44d;
 ```systemverilog {.good}
@@ -2276,9 +2276,9 @@ logic signed [15:0] sum1, sum2, sum3;
 initial begin
   a = 8'sh80;                        // a = -128
   incr = 1'b1;
-  sum1 = a + incr;                   // sum1 = 16'h0081 ( 129)
-  sum2 = a + signed'({1'b0, incr});  // sum2 = 16'hFF81 (-127)
-  sum3 = a + 8'sh01;                 // sum3 = sum2 (but simpler)
+  sum1 = a + incr;                   // bad:  sum1 = 16'h0081 ( 129)
+  sum2 = a + signed'({1'b0, incr});  // good: sum2 = 16'hFF81 (-127)
+  sum3 = a + 8'sh01;                 // good: sum3 = sum2 (more straightforward)
 end
 ```
 

--- a/VerilogCodingStyle.md
+++ b/VerilogCodingStyle.md
@@ -1566,7 +1566,7 @@ Exceptions:
 
 *   When using parameterized widths, it is acceptable to simply use `1'b1` (e.g.
     when incrementing) rather than contrivances such as
-    `{{(Bus_width-1){1'b0}},1'b1}`
+    `Bus_width'(1)`.
 *   It is acceptable to use the '0 construct to create an automatic correctly
     sized zero.
 *   Literals assigned to integer variants (e.g. byte, shortint, int, integer,
@@ -1674,7 +1674,14 @@ is to silently drop the carry on assignment.
 Example:
 
 ```systemverilog
-assign abc = abc + 4'h1;
+logic [3:0] cnt, ncnt;
+assign ncnt = cnt + 4'h1;
+```
+
+Or you may explicitly express to drop the carry by using size casting.
+
+```systemverilog
+assign ncnt = 4'(cnt + 4'h1);
 ```
 
 ### Blocking and Non-blocking Assignments

--- a/VerilogCodingStyle.md
+++ b/VerilogCodingStyle.md
@@ -1706,6 +1706,10 @@ Verilog](http://www.ece.cmu.edu/~ece447/s13/lib/exe/fetch.php?media=synth-verilo
 Synthesizable design modules must be designed around a zero-delay simulation
 methodology. All forms of `#delay`, including `#0`, are not permitted.
 
+See Cliff Cumming's [Verilog Nonblocking Assignments With Delays, Myths &
+Mysteries](http://www.sunburst-design.com/papers/CummingsSNUG2002Boston_NBAwithDelays.pdf)
+for details.
+
 ### Sequential Logic (Latches)
 
 ***The use of latches is discouraged - use flip-flops when possible.***

--- a/VerilogCodingStyle.md
+++ b/VerilogCodingStyle.md
@@ -2188,9 +2188,9 @@ end
 
 #### Wildcards in case items
 
-Use `case` instead of `case inside` nor `casez` whenever wildcard operator
-behavior is not required. When wildcard behavior is needed, use `case inside`
-(or `casez` if only Verilog-2001 is supported).
+Use `case` if wildcard operator behavior is not needed. 
+Use `case inside` if wildcard operator behavior is needed.
+Use `casez` if wildcard operator behavior is needed and Verilog-2001 compatibility is required.
 
 When expressing a wildcard in a case item, use the '?' character since it more
 clearly expresses the intent.

--- a/VerilogCodingStyle.md
+++ b/VerilogCodingStyle.md
@@ -2202,7 +2202,7 @@ performs exact matches for undriven `X` inputs. While this does not completely
 fix the problems with symmetric wildcard matching, it is harder to accidentally
 produce a `Z` input than an `X` input, so this form is preferred.
 `case inside` does not treat either `X` or `Z` in the case expression as a
-wildcard, so this form is more preferred than `casez`.
+wildcard, so this form is preferred over `casez`.
 
 References:
 


### PR DESCRIPTION
Let me propose this again.  It gets longer, but I hope this let you understand.

***

We have the following rule;

> ***Do not use `#delay` in synthesizable design modules.***

This rule does not work with a divided clock.

The following code demonstrates the issue.

```systemverilog
module tb;
    logic clk = 0;
    always
        #5ns clk = ~clk;

    logic rst_n;
    logic [3:0] d;
    always_ff @(posedge clk, negedge rst_n)
        if (~rst_n)
            d <= '0;
        else
            d <= 4'(d + 4'h1);

    // clock with nonblocking assignment
    logic clk_div_nb;
    always_ff @(posedge clk, negedge rst_n)
        if (~rst_n)
            clk_div_nb <= '0;
        else
            clk_div_nb <= ~clk_div_nb;

    logic [3:0] q_nb_ng;
    always_ff @(posedge clk_div_nb)
        q_nb_ng <= d;   // not work by race condition

    // clock with blocking assignment
    logic clk_div_b;
    always_ff @(posedge clk, negedge rst_n)
        if (~rst_n)
            clk_div_b = '0;
        else
            clk_div_b = ~clk_div_b;

    logic [3:0] q_b_ok;
    always_ff @(posedge clk_div_b)
        q_b_ok  <= d;   // works

    initial begin
        rst_n = 1'b0;
        #10ns
        rst_n = 1'b1;
        // $dumpfile("div_clock.vcd");
        // $dumpvars;
        #100ns
        $stop;
    end
endmodule
```

q_nb_ng and q_b_ok are D-Flip-flops clocked by divided clocks.  They capture the output value of d.

- d is clocked by clk.
- q_nb_ng is clocked by clk_div_nb which is divided by using non-blocking assignment (conforming our current rule).
- q_b_ok is clocked by clk_div_b which is divided by using blocking assignment (as I am proposing this pull-request).

The following is the simulation result of the sample code above.

![div_clk](https://user-images.githubusercontent.com/24754036/91857248-9eb8f500-eca2-11ea-970e-33b0274a4a1e.PNG)


q_b_ok works as we expect, but q_nb_ok does not.  For example at the timing on the yellow line they have to capture value 0b0010 as q_b_ok does.

The following shows how they works on the yellow line.

|  | previous time slot | 1st active region | 1st NBA region | 2nd active region | 2nd NBA region |
| :-- | :-: | :-: | :-: | :-: | :-: |
| clk | L | L->H | H | H | H |
| d | 0010 | 0010 | 0010->0011 | 0011 | 0011 |
| clk\_div\_nb | L | L | **L->H** | H | H |
| q\_nb\_ng | 0001 | 0001 | 0001 | 0001 | **0001->0011** |
| clk\_div\_b | L | L->H | H | H | H |
| q\_b\_ok | 0000 | 0000 | 0000->0010 | 0010 | 0010 |

1. clk_div_nb (non-blocking) is asserted at the first NBA region.
2. The state goes back to the second active region and at the 2nd NBA region q_nb_ng captures value (0b0011) of d updated at the first NBA region of this time slot.

This is not the behavior expected.  (cf. LRM 2017 Figure 4-1—Event scheduling regions)

***

Plan B: Use `#delay` for all FFs (when we have a divided clock)

Many engineers are choosing this solution.  But we know this degrades simulation performance.

Plan C: Use `#delay` for FFs clocked by divided clock and capture signals derived from FFs clocked by the original clock.

This may be better performance than plan B, but very easy to cause bugs.

***

I should create a branch after fetching updated upstream.  Sorry.
