### PR TITLE
Format module port expressions in tabular style

### DIFF
--- a/VerilogCodingStyle.md
+++ b/VerilogCodingStyle.md
@@ -459,7 +459,7 @@ assign bus_concatenation = {
 };
 
 inst_type inst_name1 (
-  .clk_i    (clk),
+  .clk_i       (clk),
   .data_valid_i(data_valid),
   .data_value_i(data_value),
   .data_ready_o(data_ready)
@@ -521,21 +521,47 @@ mymodule mymodule(.a(a),.b(b));
 
 #### Tabular Alignment
 
-***Adding whitespace to cause related things to align is encouraged.***
+Tabular alignment groups two or more similar lines so that the identical parts are directly above one another.
+This alignment makes it easy to see which characters are the same and which characters are different between lines.
 
-Where it is reasonable to do so, align a group of two or more similar lines so
-that the identical parts are directly above one another. This alignment makes it
-easy to see which characters are the same and which characters are different
-between lines.
+***The use of tabular alignment is generally encouraged.***
+
+***The use of tabular alignment is required for some constructs as detailed in the corresponding subsection of this guide.***
+
+Constructs which require tabular alignment:
+
+* [Port expressions in module instantiations](#module-instantiation)
+
+Each block of code, separated by an empty line, is treated as separate "table".
 
 Use spaces, not tabs.
 
 For example:
 
+:+1:
 ```systemverilog
 logic [7:0]  my_interface_data;
 logic [15:0] my_interface_address;
 logic        my_interface_enable;
+
+logic       another_signal;
+logic [7:0] something_else;
+```
+
+:+1:
+```systemverilog
+mod u_mod (
+  .clk_i,
+  .rst_ni,
+  .sig_i          (my_signal_in),
+  .sig2_i         (my_signal_out),
+  // comment with no blank line maintains the block
+  .in_same_block_i(my_signal_in),
+  .sig3_i         (something),
+
+  .in_another_block_i(my_signal_in),
+  .sig4_i            (something)
+);
 ```
 
 #### Expressions
@@ -933,8 +959,8 @@ module my_module #(
     .clk_i,
     .rst_ni,
     .req_valid_i,
-    .req_data_i    (req_data_masked),
-    .req_ready_o,
+    .req_data_i (req_data_masked),
+    .req_ready_o(req_ready),
     ...
   );
 
@@ -1507,6 +1533,31 @@ Do not use positional arguments to connect signals to ports.
 
 Instantiate ports in the same order as they are defined in the module.
 
+Align port expressions in [tabular style](#tabular-alignment).
+Do not include whitespace before the opening parenthesis of the longest port name.
+Do not include whitespace after the opening parenthesis, or before the closing parenthesis enclosing the port expression.
+
+:-1:
+```systemverilog
+mod u_mod(
+  .clk_i,
+  .rst_ni,
+
+  // Not allowed: avoid leading/trailing whitespace in expressions.
+  .sig_1_i( sig_1 ),
+  .sig_2_i( sig_2 )
+);
+
+mod u_mod(
+  .clk_i,
+  .rst_ni,
+
+  .short_sig_i                       (sig_1),
+  // Not allowed: avoid whitespace between the longest signal name and the opening parenthesis.
+  .a_very_long_signal_name_indeed_i  (sig_2)
+);
+```
+
 ***Use named parameters for all instantiations.***
 
 When parameterizing an instance, specify the parameter using the named parameter
@@ -1521,10 +1572,15 @@ my_module #(
   .Height(5),
   .Width(10)
 ) my_module (
-  ...etc...
+  // ...
+);
 
-my_reg #(16) my_reg0 (.clk_i, .rst_ni, .d_i(data_in), .q_o(data_out));
-
+my_reg #(16) my_reg0 (
+  .clk_i,
+  .rst_ni,
+  .d_i   (data_in),
+  .q_o   (data_out)
+);
 ```
 Do not specify parameters positionally, unless there is only one parameter and
 the intent of that parameter is obvious, such as the width for a register

--- a/VerilogCodingStyle.md
+++ b/VerilogCodingStyle.md
@@ -97,9 +97,12 @@ representation of this style guide.
     - [Sequential Logic (Latches)](#sequential-logic-latches)
     - [Sequential Logic (Registers)](#sequential-logic-registers)
     - [Don't Cares (`X`'s)](#dont-cares-xs)
+      - [Catching errors where invalid values are consumed](#catching-errors-where-invalid-values-are-consumed)
+      - [Specific Guidance on Case Statements and Ternaries](#specific-guidance-on-case-statements-and-ternaries)
+      - [Dynamic Array Indexing](#dynamic-array-indexing)
     - [Combinational Logic](#combinational-logic)
     - [Case Statements](#case-statements)
-        - [Wildcards in case items](#wildcards-in-case-items)
+      - [Wildcards in case items](#wildcards-in-case-items)
     - [Generate Constructs](#generate-constructs)
     - [Signed Arithmetic](#signed-arithmetic)
     - [Number Formatting](#number-formatting)
@@ -118,11 +121,13 @@ representation of this style guide.
     - [Differential Pairs](#differential-pairs)
     - [Delays](#delays)
     - [Wildcard import of packages](#wildcard-import-of-packages)
+    - [Assertion Macros](#assertion-macros)
+      - [A Note on Security Critical Applications](#a-note-on-security-critical-applications)
   - [Appendix - Condensed Style Guide](#appendix---condensed-style-guide)
     - [Basic Style Elements](#basic-style-elements)
     - [Construct Naming](#construct-naming)
     - [Suffixes for signals and types](#suffixes-for-signals-and-types)
-    - [Language features](#language-features)
+    - [Language features](#language-features-1)
 
 
 ### Terminology Conventions

--- a/VerilogCodingStyle.md
+++ b/VerilogCodingStyle.md
@@ -84,7 +84,7 @@ representation of this style guide.
     - [Preferred SystemVerilog Constructs](#preferred-systemverilog-constructs)
     - [Package Dependencies](#package-dependencies)
     - [Module Declaration](#module-declaration)
-    - [Parameterized Module Instantiation](#parameterized-module-instantiation)
+    - [Module Instantiation](#module-instantiation)
     - [Constants](#constants-1)
     - [Signal Widths](#signal-widths)
       - [Always be explicit about the widths of number literals.](#always-be-explicit-about-the-widths-of-number-literals)
@@ -1468,32 +1468,7 @@ output logic b;
 ...
 ```
 
-### Parameterized Module Instantiation
-
-***Use named parameters for all instantiations.***
-
-When parameterizing an instance, specify the parameter using the named parameter
-style. An exception is if there is only one parameter that is obvious such as
-register width, then the instantiation can be implicit.
-
-Indentation for module instantiation follows the standard indentation
-rule of two space indentation.
-
-```systemverilog
-my_module #(
-  .Height(5),
-  .Width(10)
-) my_module (
-  ...etc...
-
-my_reg #(16) my_reg0 (.clk_i, .rst_ni, .d_i(data_in), .q_o(data_out));
-
-```
-Do not specify parameters positionally, unless there is only one parameter and
-the intent of that parameter is obvious, such as the width for a register
-instance.
-
-Do not use `defparam`.
+### Module Instantiation
 
 ***Use named ports to fully specify all instantiations.***
 
@@ -1531,6 +1506,31 @@ example: `.unused_input_port(8'd0)`)
 Do not use positional arguments to connect signals to ports.
 
 Instantiate ports in the same order as they are defined in the module.
+
+***Use named parameters for all instantiations.***
+
+When parameterizing an instance, specify the parameter using the named parameter
+style. An exception is if there is only one parameter that is obvious such as
+register width, then the instantiation can be implicit.
+
+Indentation for module instantiation follows the standard indentation
+rule of two space indentation.
+
+```systemverilog
+my_module #(
+  .Height(5),
+  .Width(10)
+) my_module (
+  ...etc...
+
+my_reg #(16) my_reg0 (.clk_i, .rst_ni, .d_i(data_in), .q_o(data_out));
+
+```
+Do not specify parameters positionally, unless there is only one parameter and
+the intent of that parameter is obvious, such as the width for a register
+instance.
+
+Do not use `defparam`.
 
 ***Do not instantiate recursively.***
 


### PR DESCRIPTION
Port expressions in module instantiations should be formatted in tabular style, as discussed in #48.