### PR TITLE
Fix example code

### DIFF
--- a/VerilogCodingStyle.md
+++ b/VerilogCodingStyle.md
@@ -1919,7 +1919,7 @@ module mymod (
   logic special_action_en;
 
   assign special_action_en =
-    (external_addr_i == SPECIAL_ADDR) & external_wr_en_i;
+      (external_addr_i == SPECIAL_ADDR) & external_wr_en_i;
 
   `ASSERT_KNOWN(special_action_en)
 

--- a/VerilogCodingStyle.md
+++ b/VerilogCodingStyle.md
@@ -1921,7 +1921,7 @@ module mymod (
   assign special_action_en =
     (external_addr_i == SPECIAL_ADDR) & external_wr_en_i;
 
-  `ASSERT_KNOWN(special_action_en);
+  `ASSERT_KNOWN(special_action_en)
 
 endmodule
 ```


### PR DESCRIPTION
The example code in "Catching errors where invalid values are consumed" didn't comply with our own style guide, fix that.