### PR TITLE
add a reference to sv-tests

### DIFF
--- a/VerilogCodingStyle.md
+++ b/VerilogCodingStyle.md
@@ -2547,6 +2547,11 @@ unless otherwise noted:
 -   Interfaces.
 -   The `alias` statement.
 
+To make sure that a language feature is widely supported, tools like
+[sv-tests][svt] can be used for a non-exhaustive overview.
+
+[svt]: https://chipsalliance.github.io/sv-tests-results/
+
 #### Floating begin-end blocks
 
 The use of generate blocks other than `for` loop, `if`, or `case` generate


### PR DESCRIPTION
This is a request for comments.

In #52 were discussed the use of SystemVerilog interfaces, and the reason stated was the absence of a complete tooling support. It is true that a few major tools part of the open source toolchain do not support them fully, like [yosys](https://chipsalliance.github.io/sv-tests-results/?v=yosys+25.3+interface) for which it is WIP.

What about a referencne to sv-tests? This would hint that the motivation is not that interfaces are a confusing feature, but rather a poorly supported one.

If not interesting to have it there, feel free to close this.